### PR TITLE
Bugfix: plugin installer crash on non-text responses

### DIFF
--- a/+masiv/@pluginManager/processResponseSubsection.m
+++ b/+masiv/@pluginManager/processResponseSubsection.m
@@ -20,7 +20,7 @@ function [subsectionName,data]=processResponseSubsection(response)
     end
     block = block{1}{1};
 
-    tok=regexp(block,'"(.+?)"\: *"(.*?)"','tokens');
+    tok=regexp(block,'"(.+?)"\: *"?(.*?)"?[,}]','tokens');
     if isempty(tok)
         error('failed to get data from sub-section')
     end


### PR DESCRIPTION
processResponseSubsection was failing if any of the responses contains a `false` or `null` or anything with not surrounded by "".
Change the regexp to match these cases.

Should fix #21